### PR TITLE
added: custom image failure response

### DIFF
--- a/Classes/IDMPhoto.m
+++ b/Classes/IDMPhoto.m
@@ -145,8 +145,8 @@ caption = _caption;
             } completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
                 if (image) {
                     self.underlyingImage = image;
-                    [self performSelectorOnMainThread:@selector(imageLoadingComplete) withObject:nil waitUntilDone:NO];
                 }
+                [self performSelectorOnMainThread:@selector(imageLoadingComplete) withObject:nil waitUntilDone:NO];
             }];
 
         } else {

--- a/Classes/IDMPhotoBrowser.h
+++ b/Classes/IDMPhotoBrowser.h
@@ -12,6 +12,7 @@
 #import "IDMPhoto.h"
 #import "IDMPhotoProtocol.h"
 #import "IDMCaptionView.h"
+#import "IDMTapDetectingImageView.h"
 
 // Delgate
 @class IDMPhotoBrowser;
@@ -24,7 +25,7 @@
 - (void)photoBrowser:(IDMPhotoBrowser *)photoBrowser willDismissAtPageIndex:(NSUInteger)index;
 - (void)photoBrowser:(IDMPhotoBrowser *)photoBrowser didDismissActionSheetWithButtonIndex:(NSUInteger)buttonIndex photoIndex:(NSUInteger)photoIndex;
 - (IDMCaptionView *)photoBrowser:(IDMPhotoBrowser *)photoBrowser captionViewForPhotoAtIndex:(NSUInteger)index;
-- (void)photoBrowser:(IDMPhotoBrowser *)photoBrowser imageFailed:(NSUInteger)index;
+- (void)photoBrowser:(IDMPhotoBrowser *)photoBrowser imageFailed:(NSUInteger)index imageView:(IDMTapDetectingImageView *)imageView;
 @end
 
 // IDMPhotoBrowser

--- a/Classes/IDMPhotoBrowser.h
+++ b/Classes/IDMPhotoBrowser.h
@@ -88,4 +88,6 @@
 // Get IDMPhoto at index
 - (id<IDMPhoto>)photoAtIndex:(NSUInteger)index;
 
+// Override this to specify custom image failure response
+-(void)displayImageFailure:(UIImageView*)imageView;
 @end

--- a/Classes/IDMPhotoBrowser.h
+++ b/Classes/IDMPhotoBrowser.h
@@ -24,6 +24,7 @@
 - (void)photoBrowser:(IDMPhotoBrowser *)photoBrowser willDismissAtPageIndex:(NSUInteger)index;
 - (void)photoBrowser:(IDMPhotoBrowser *)photoBrowser didDismissActionSheetWithButtonIndex:(NSUInteger)buttonIndex photoIndex:(NSUInteger)photoIndex;
 - (IDMCaptionView *)photoBrowser:(IDMPhotoBrowser *)photoBrowser captionViewForPhotoAtIndex:(NSUInteger)index;
+- (void)photoBrowser:(IDMPhotoBrowser *)photoBrowser imageFailed:(NSUInteger)index;
 @end
 
 // IDMPhotoBrowser
@@ -88,6 +89,4 @@
 // Get IDMPhoto at index
 - (id<IDMPhoto>)photoAtIndex:(NSUInteger)index;
 
-// Override this to specify custom image failure response
--(void)displayImageFailure:(UIImageView*)imageView;
 @end

--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -925,8 +925,6 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
     }
 }
 
--(void)displayImageFailure:(UIImageView*)imageView {}
-
 #pragma mark - IDMPhoto Loading Notification
 
 - (void)handleIDMPhotoLoadingDidEndNotification:(NSNotification *)notification {
@@ -940,6 +938,12 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
         } else {
             // Failed to load
             [page displayImageFailure];
+            if ([_delegate respondsToSelector:@selector(photoBrowser:imageFailed:)]) {
+                NSUInteger pageIndex = PAGE_INDEX(page);
+                [_delegate photoBrowser:self imageFailed:pageIndex];
+            }
+            // make sure the page is completely updated
+            [page setNeedsLayout];
         }
     }
 }

--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -925,6 +925,8 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
     }
 }
 
+-(void)displayImageFailure:(UIImageView*)imageView {}
+
 #pragma mark - IDMPhoto Loading Notification
 
 - (void)handleIDMPhotoLoadingDidEndNotification:(NSNotification *)notification {
@@ -1379,5 +1381,4 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
 		}];
 	}
 }
-
 @end

--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -938,9 +938,9 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
         } else {
             // Failed to load
             [page displayImageFailure];
-            if ([_delegate respondsToSelector:@selector(photoBrowser:imageFailed:)]) {
+            if ([_delegate respondsToSelector:@selector(photoBrowser:imageFailed:imageView:)]) {
                 NSUInteger pageIndex = PAGE_INDEX(page);
-                [_delegate photoBrowser:self imageFailed:pageIndex];
+                [_delegate photoBrowser:self imageFailed:pageIndex imageView:page.photoImageView];
             }
             // make sure the page is completely updated
             [page setNeedsLayout];

--- a/Classes/IDMZoomingScrollView.m
+++ b/Classes/IDMZoomingScrollView.m
@@ -151,8 +151,6 @@
 // Image failed so just show black!
 - (void)displayImageFailure {
     [_progressView removeFromSuperview];
-    [_photoBrowser displayImageFailure:_photoImageView];
-    [self setNeedsLayout];
 }
 
 #pragma mark - Setup

--- a/Classes/IDMZoomingScrollView.m
+++ b/Classes/IDMZoomingScrollView.m
@@ -151,6 +151,8 @@
 // Image failed so just show black!
 - (void)displayImageFailure {
     [_progressView removeFromSuperview];
+    [_photoBrowser displayImageFailure:_photoImageView];
+    [self setNeedsLayout];
 }
 
 #pragma mark - Setup


### PR DESCRIPTION
When an image fails to load there is no way to implement a custom behaviour for this. I've added a method to `IDMPhotoBrowserDelegate` that will be called when an image fails to load. The method will also pass in the `UIImageView` so a custom image may be shown.

I'd also like to note that `IDMZoomingScrollView`'s `displayImageFailure` method was never called due to `imageLoadingComplete` not being called unless the image succeeded. I've fixed this with my change to `IDMPhoto`. I can make this a separate commit, if you'd like.