### PR TITLE
Improve support for subclassing IDMCaptionView

### DIFF
--- a/Classes/IDMCaptionView.h
+++ b/Classes/IDMCaptionView.h
@@ -11,6 +11,9 @@
 
 @interface IDMCaptionView : UIView
 
+@property (nonatomic, strong) UILabel *label;
+@property (nonatomic, strong, readonly) id<IDMPhoto> photo;
+
 // Init
 - (id)initWithPhoto:(id<IDMPhoto>)photo;
 

--- a/Classes/IDMCaptionView.m
+++ b/Classes/IDMCaptionView.m
@@ -13,13 +13,16 @@
 static const CGFloat labelPadding = 10;
 
 // Private
-@interface IDMCaptionView () {
-    id<IDMPhoto> _photo;
-    UILabel *_label;    
-}
+@interface IDMCaptionView ()
+
+@property (nonatomic, strong, readwrite) id<IDMPhoto> photo;
+
 @end
 
 @implementation IDMCaptionView
+
+@synthesize label = _label;
+@synthesize photo = _photo;
 
 - (id)initWithPhoto:(id<IDMPhoto>)photo {
     CGRect screenBound = [[UIScreen mainScreen] bounds];


### PR DESCRIPTION
Expose label so it can be used by subclasses on `-setupCaption`.

