### PR TITLE
Incorrect done button position

### DIFF
--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -615,7 +615,7 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
         _doneButton.layer.cornerRadius = 3.0f;
         _doneButton.layer.borderColor = [UIColor colorWithWhite:0.9 alpha:0.9].CGColor;
         _doneButton.layer.borderWidth = 1.0f;
-        _doneButtonSize = _doneButtonImage.size;
+        _doneButtonSize = _doneButton.frame.size;
     }
     else {
         [_doneButton setImage:_doneButtonImage forState:UIControlStateNormal];


### PR DESCRIPTION
In the code below the `_doneButtonSize` variable is set based on `_doneButtonImage.size` after just confirming that `_doneButtonImage` is `NULL`. Therefore the size will always have a width and height of zero unless using a custom done button image. This is fixed by using the frame which is set based on orientation.