### PR TITLE
add access request

### DIFF
--- a/Demo/PhotoBrowserDemo/PhotoBrowserDemo-Info.plist
+++ b/Demo/PhotoBrowserDemo/PhotoBrowserDemo-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>need to access your photo Library</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
iOS11 need to add "Privacy - Photo Library Additions Usage Description" key in info.plist to get Photo Library access, or the application would crash. 