### PR TITLE
Moves SDWebImage dependency to a newer version with fewer crashes

### DIFF
--- a/IDMPhotoBrowser.podspec
+++ b/IDMPhotoBrowser.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.resources     =  'Classes/IDMPhotoBrowser.bundle', 'Classes/IDMPBLocalizations.bundle'
   s.framework     =  'MessageUI', 'QuartzCore', 'SystemConfiguration', 'MobileCoreServices', 'Security'
   s.requires_arc  =  true
-  s.dependency       'SDWebImage', '4.0.0'
+  s.dependency       'SDWebImage', '4.2.2'
   s.dependency       'DACircularProgress'
   s.dependency       'pop'
   end


### PR DESCRIPTION
I've tested this in circumstances that regularly led the older version to crash, and I haven't seen problems in the newer version.