### PR TITLE
fix Splash screen when dismiss PhotoBrowser

### DIFF
--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -1295,6 +1295,7 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
 #pragma mark - Buttons
 
 - (void)doneButtonPressed:(id)sender {
+    _dismissOnTouch = NO;
     if ([_delegate respondsToSelector:@selector(willDisappearPhotoBrowser:)]) {
         [_delegate willDisappearPhotoBrowser:self];
     }


### PR DESCRIPTION
tap white area or click done ，then  Quick  PhotoBrowser imageview，it
will Splash screen。 so set  _dismissOnTouch = NO;